### PR TITLE
Get the CoreDNS to a working state

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Make sure you've got the [coredns-interface](https://github.com/DomFleischmann/c
 
 ## How to deploy the charm
 
-For deploying the charm you will have to have a kubernetes cluster bootstrapped with juju to be able to deploy kubernetes charms. Than you will simply need to execute the following in the charm builds dir:  
+For deploying the charm you will have to have a kubernetes cluster bootstrapped with juju (more information [here](https://jaas.ai/docs/k8s-cloud) to be able to deploy kubernetes charms. Than you will simply need to execute the following in the charm builds dir:  
 ``` juju deploy ./coredns --resource coredns-image=rocks.canonical.com:443/cdk/coredns/coredns-amd64:1.6.2 ```
 
 ## How to add the relation
@@ -17,3 +17,4 @@ You can use the coredns interface to automatically configure the CoreDNS charm w
 ```juju offer kubernetes-worker:coredns```
 And the following in the model where CoreDNS has been deployed:
 ```juju add-relation coredns <offer-url>```
+This will reconfigure the kubelet with the service IP of this CoreDNS.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # CoreDNS
 
-CoreDNS is a DNS server.
+CoreDNS is a DNS  server. And this is a Kubernetes Charm to deploy CoreDNS on Kubernetes with Juju.
+
+## How to build the charm
+
+Make sure you've got the [coredns-interface](https://github.com/DomFleischmann/coredns-interface) in your $CHARM_INTERFACES_DIR and simply build the charm with:
+``` charm build charm-coredns -o ..```
+
+## How to deploy the charm
+
+For deploying the charm you will have to have a kubernetes cluster bootstrapped with juju to be able to deploy kubernetes charms. Than you will simply need to execute the following in the charm builds dir:  
+``` juju deploy ./coredns --resource coredns-image=rocks.canonical.com:443/cdk/coredns/coredns-amd64:1.6.2 ```
+
+## How to add the relation
+You can use the coredns interface to automatically configure the CoreDNS charm with Charmed Kubernetes. For that execute the following inside of the Charmed Kubernetes model:
+```juju offer kubernetes-worker:coredns```
+And the following in the model where CoreDNS has been deployed:
+```juju add-relation coredns <offer-url>```

--- a/config.yaml
+++ b/config.yaml
@@ -3,4 +3,8 @@ options:
   port:
     type: string
     description: 'Port that coredns will list on'
-    default: '1053'
+    default: '53'
+  dns_domain:
+    type: string
+    description: "DNS domain that will be used"
+    default: 'cluster.local'

--- a/files/CoreFile
+++ b/files/CoreFile
@@ -1,0 +1,16 @@
+.:%(port)s {
+    errors
+    health
+    ready
+    kubernetes %(dns_domain)s in-addr.arpa ip6.arpa {
+      pods insecure
+      fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . /etc/resolv.conf
+    cache 30
+    loop
+    reload
+    loadbalance
+}
+

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,5 @@
 repo: https://github.com/charmed-kubernetes/charm-coredns.git
 includes:
   - "layer:caas-base"
-  - "layer:docker-resource"  # this should be folded into reactive
+  - "layer:docker-resource"  
+  - "interface:coredns"  

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,9 @@ tags:
   - kubernetes
 series:
    - kubernetes
+provides:
+  coredns:
+    interface: coredns
 resources:
   coredns-image:
     type: oci-image

--- a/reactive/coredns.py
+++ b/reactive/coredns.py
@@ -19,8 +19,6 @@ def start_charm():
 
     corefile = Path('files/CoreFile').read_text() % config
 
-    print('COREFILE: {}'.format(corefile))
-    print('PORT: {}'.format(hookenv.config('port')))
     layer.caas_base.pod_spec_set({
         'serviceAccount': {
             'rules': [
@@ -95,6 +93,8 @@ def send_ip():
             if service_ip:
                 coredns.send_ip(service_ip)
                 clear_flag('coredns.joined')
+            else:
+                layer.status.blocked('Unable to get service IP')
     except Exception as e:
         hookenv.log("Failed sending CoreDNS IP: {}".format(e))
 
@@ -106,6 +106,8 @@ def get_service_ip(endpoint):
             addr = info['ingress-addresses'][0]
             if len(addr):
                 return addr
+            else:
+                hookenv.log("No addresses in ingress-addresses: {}".format(info))
         else:
             hookenv.log("No ingress-addresses: {}".format(info))
     except Exception as e:

--- a/reactive/coredns.py
+++ b/reactive/coredns.py
@@ -1,5 +1,7 @@
+from pathlib import Path
+
 from charmhelpers.core import hookenv
-from charms.reactive import set_flag, clear_flag
+from charms.reactive import set_flag, clear_flag, endpoint_from_flag
 from charms.reactive import when, when_not
 
 from charms import layer
@@ -14,9 +16,33 @@ def start_charm():
     image_info = layer.docker_resource.get_info('coredns-image')
 
     config = hookenv.config()
-    port = config.get('port')
 
+    corefile = Path('files/CoreFile').read_text() % config
+
+    print('COREFILE: {}'.format(corefile))
+    print('PORT: {}'.format(hookenv.config('port')))
     layer.caas_base.pod_spec_set({
+        'serviceAccount': {
+            'rules': [
+                {
+                    'apiGroups': [''],
+                    'resources': ['endpoints', 'services', 'pods', 'namespaces'],
+                    'verbs': ['list', 'watch'],
+                },
+                {
+                    'apiGroups': [''],
+                    'resources': ['nodes'],
+                    'verbs': ['get'],
+                },
+            ]
+        },
+        'service': {
+            'lables': {
+                'k8s-app': 'kube-dns',
+                'kubernetes.io/cluster-service': 'true',
+                'kubernetes.io/name': "CoreDNS",
+             },
+        },
         'containers': [
             {
                 'name': 'coredns-service',
@@ -25,16 +51,24 @@ def start_charm():
                     'username': image_info.username,
                     'password': image_info.password,
                 },
-                'command': ['/coredns', '-dns.port={}'.format(port)],
+                'args': ["-conf", "/etc/coredns/CoreFile"],
                 'ports': [
+                    {'name': 'dns', 'containerPort': int(hookenv.config('port')), 'protocol': 'UDP'},
+                    {'name': 'dns-tcp', 'containerPort': int(hookenv.config('port')), 'protocol': 'TCP'},
+                    {'name': 'metrics', 'containerPort': 9153, 'protocol': 'TCP'},
+                ],
+                'readinessProbe': {
+                    'httpGet': {'path': '/ready', 'port': 8181, 'scheme': 'HTTP'},
+                },
+                'files': [
                     {
-                        'name': 'dns',
-                        'containerPort': 1053,
+                        'name': 'config',
+                        'mountPath': '/etc/coredns',
+                        'files': {
+                            'CoreFile': corefile,
+                        },
                     },
                 ],
-                'config': {
-                    'K8S_MODEL': hookenv.model_name(),
-                },
             },
         ],
     })
@@ -47,3 +81,34 @@ def start_charm():
 def update_image():
     # handle a new image resource becoming available
     clear_flag('charm.coredns.started')
+
+
+@when('charm.coredns.started', 'coredns.joined')
+def send_ip():
+    """
+    Send CoreDNS IP to kuberentes-worker
+    """
+    try:
+        coredns = endpoint_from_flag('coredns.joined')
+        if coredns:
+            service_ip = get_service_ip('coredns')
+            if service_ip:
+                coredns.send_ip(service_ip)
+                clear_flag('coredns.joined')
+    except Exception as e:
+        hookenv.log("Failed sending CoreDNS IP: {}".format(e))
+
+
+def get_service_ip(endpoint):
+    try:
+        info = hookenv.network_get(endpoint, hookenv.relation_id())
+        if 'ingress-addresses' in info:
+            addr = info['ingress-addresses'][0]
+            if len(addr):
+                return addr
+        else:
+            hookenv.log("No ingress-addresses: {}".format(info))
+    except Exception as e:
+        hookenv.log("Caught exception checking for service IP: {}".format(e))
+
+    return None


### PR DESCRIPTION
This will get the CoreDNS charm to a working state so that it can be
deployed and used in any cluster by setting the ClusterDNS value of
the kubelets. In the case of Charmed Kubernetes this can be done by
adding a relation to the kubernetes-worker charm.