### PR TITLE
Clean up build scripts

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,23 +1,19 @@
 #!/bin/bash
 
+set -e
+
 export PATH="/snap/bin:$PATH"
 
 if [[ "$(snap whoami)" == "email: -" ]]; then
-    snap_sudo="sudo"
+    snap="sudo snap"
 else
-    snap_sudo=""
+    snap="snap"
 fi
 
 echo "Verifying dependencies..."
-apt_updated=false
-if ! (which docker && which make && which unzip) > /dev/null; then
+if ! (which make && which unzip) > /dev/null; then
     echo "Updating apt..."
     sudo apt update -yqq
-    apt_updated=true
-fi
-if ! which docker > /dev/null; then
-    echo "Installing docker..."
-    sudo apt install -qyf docker.io
 fi
 if ! which make > /dev/null; then
     echo "Installing make..."
@@ -27,32 +23,15 @@ if ! which unzip > /dev/null; then
     echo "Installing unzip..."
     sudo apt install -qyf unzip
 fi
-if [[ "$HOME" != "/home/"* ]]; then
-    # If we're in an environment that has a non-/home HOME (like Jenkins),
-    # then we have to use the pip installed charmcraft due to:
-    # https://forum.snapcraft.io/t/support-for-non-home-homedirs/11209
-    if ! which pip3 > /dev/null; then
-        if [[ $apt_updated == "false" ]]; then
-            echo "Updating apt..."
-            sudo apt update -yqq
-            apt_updated=true
-        fi
-        echo "Installing python3-pip..."
-        sudo apt install -qyf python3-pip
-    fi
-    if [[ -z "$VIRTUAL_ENV" ]]; then
-        echo "Installing charmcraft as user package..."
-        pip3 install --user charmcraft
-    else
-        echo "Installing charmcraft into venv..."
-        # Can just install directly into the active venv
-        pip3 install charmcraft
-    fi
-elif ! which charmcraft > /dev/null; then
+if ! which docker > /dev/null; then
+    echo "Installing docker..."
+    $snap install docker
+fi
+if ! which charmcraft > /dev/null; then
     echo "Installing charmcraft snap..."
-    $snap_sudo snap install charmcraft --beta
+    $snap install charmcraft --beta
 fi
 if ! which yq > /dev/null; then
     echo "Installing yq..."
-    $snap_sudo snap install yq
+    $snap install yq
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -e
+set -eu
 
 export PATH="/snap/bin:$PATH"
 

--- a/script/build
+++ b/script/build
@@ -6,7 +6,7 @@ export PATH=/snap/bin:$PATH
 
 mkdir -p "$CHARM_BUILD_DIR"
 
-CHARM_SRC="$(realpath "$CHARM")"
+CHARM_SRC="$(realpath .)"
 
 echo "Building $CHARM..."
 (cd "$CHARM_BUILD_DIR" && charmcraft build -f "$CHARM_SRC" 2>&1) | sed -e "s,in ',in '$CHARM_BUILD_DIR/,"

--- a/script/build
+++ b/script/build
@@ -6,36 +6,8 @@ export PATH=/snap/bin:$PATH
 
 mkdir -p "$CHARM_BUILD_DIR"
 
-CHARM_SRC="$(realpath .)"
-CHARM_DST="$CHARM_BUILD_DIR/$CHARM.charm"
-CHARM_DST_UNZIP="$CHARM_BUILD_DIR/$CHARM"
-
-# Use pip version of charmcraft if available due to
-# issue with non-standard HOME causing problems in CI:
-# https://forum.snapcraft.io/t/support-for-non-home-homedirs/11209
-if [[ -x "$VIRTUAL_ENV/bin/charmcraft" ]]; then
-    # Use charmcraft from the active venv
-    CHARMCRAFT="$VIRTUAL_ENV/bin/charmcraft"
-elif [[ -x $HOME/.local/bin/charmcraft ]]; then
-    # Use charmcraft from user pacakage
-    CHARMCRAFT="$HOME/.local/bin/charmcraft"
-else
-    # Use charmcraft snap
-    CHARMCRAFT="/snap/bin/charmcraft"
-fi
+CHARM_SRC="$(realpath "$CHARM")"
 
 echo "Building $CHARM..."
-(cd "$CHARM_BUILD_DIR" && "$CHARMCRAFT" build -f "$CHARM_SRC" 2>&1) | sed -e "s,in '.*,in '$CHARM_DST',"
-build_exit_code=${PIPESTATUS[0]}
-if [[ $build_exit_code != 0 ]]; then
-    exit "$build_exit_code"
-fi
-
-if [[ "$HOME" == *jenkins* ]]; then
-    # also provide unzipped version for `charm push` for Jenkins
-    echo "Unpacking $CHARM_DST to $CHARM_DST_UNZIP..."
-    rm -rf "$CHARM_DST_UNZIP"
-    mkdir -p "$CHARM_DST_UNZIP"
-    unzip -q "$CHARM_DST" -d "$CHARM_DST_UNZIP"
-    echo "Done."
-fi
+(cd "$CHARM_BUILD_DIR" && charmcraft build -f "$CHARM_SRC" 2>&1) | sed -e "s,in ',in '$CHARM_BUILD_DIR/,"
+exit "${PIPESTATUS[0]}"

--- a/script/build
+++ b/script/build
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -e
+set -eu
 
 export PATH=/snap/bin:$PATH
 

--- a/script/update
+++ b/script/update
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 echo "Verifying dependencies"
 if ! which pipenv > /dev/null; then

--- a/script/upload
+++ b/script/upload
@@ -22,4 +22,5 @@ echo "Attached: $IMAGE_NAME-$IMAGE_REV"
 
 if [ "$CHANNEL" != unpublished ]; then
    charm release "$URL" --channel "$CHANNEL" --resource "$IMAGE_NAME"-"$IMAGE_REV"
+   echo "Released to: $CHANNEL"
 fi

--- a/script/upload
+++ b/script/upload
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-set -e
+set -eu
 
 export PATH=/snap/bin:$PATH
 
@@ -21,6 +20,6 @@ IMAGE_REV=$(charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished "$IMAGE
 echo "Attached: $IMAGE_NAME-$IMAGE_REV"
 
 if [ "$CHANNEL" != unpublished ]; then
-   charm release "$URL" --channel "$CHANNEL" --resource "$IMAGE_NAME"-"$IMAGE_REV"
-   echo "Released to: $CHANNEL"
+    charm release "$URL" --channel "$CHANNEL" --resource "$IMAGE_NAME"-"$IMAGE_REV"
+    echo "Released to: $CHANNEL"
 fi

--- a/script/upload
+++ b/script/upload
@@ -9,19 +9,12 @@ if ! charm whoami > /dev/null; then
     exit 1
 fi
 
-CHARM_DST_UNZIP="$CHARM_BUILD_DIR/$CHARM"
-
-if [ ! -e "$CHARM_DST_UNZIP" ]; then
-    echo "Built charm not found" 2>&1
-    exit 1
-fi
-
 
 IMAGE_NAME="$CHARM-image"
-IMAGE=$(yq r "charms/$CHARM/metadata.yaml" "resources.$IMAGE_NAME.upstream-source")
+IMAGE=$(yq r "metadata.yaml" "resources.$IMAGE_NAME.upstream-source")
 docker pull "$IMAGE"
 
-URL=$(charm push "$CHARM_DST_UNZIP" "cs:~$NAMESPACE/$CHARM" | yq r - url)
+URL=$(charm push "$CHARM_BUILD_DIR/$CHARM.charm" "cs:~$NAMESPACE/$CHARM" | yq r - url)
 echo "Uploaded: $URL"
 
 IMAGE_REV=$(charm attach cs:~"$NAMESPACE"/"$CHARM" --channel unpublished "$IMAGE_NAME=$IMAGE" | tail -n1 | sed -e 's/uploaded revision \([0-9]*\) of.*/\1/')


### PR DESCRIPTION
Now that `charm push` can handle `.charm` files and we cleaned up handling of charmcraft on CI, we can remove a lot of messy code from the build scripts.