### PR TITLE
Remove layer.yaml missed during conversion

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,4 +1,0 @@
-repo: https://github.com/charmed-kubernetes/charm-coredns.git
-includes:
-  - "layer:caas-base"
-  - "layer:docker-resource"  # this should be folded into reactive


### PR DESCRIPTION
This is causing CI to detect this as a legacy `charm build` charm.