### PR TITLE
add missing permissions for coredns

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,6 @@
+type: charm
+parts:
+  charm:
+    build-packages: [git]
+    prime:
+      - ./files/*

--- a/src/charm.py
+++ b/src/charm.py
@@ -127,6 +127,13 @@ class CoreDNSCharm(CharmBase):
                     'global': True,
                     'rules': [
                         {
+                            'apigroups': ['discovery.k8s.io'],
+                            'resources': [
+                                'endpointslices',
+                            ],
+                            'verbs': ['list', 'watch'],
+                        },
+                        {
                             'apigroups': [''],
                             'resources': [
                                 'endpoints',


### PR DESCRIPTION
Add missing discovery.k8s.io permissions See: [LP1949210](https://bugs.launchpad.net/charm-coredns/+bug/1949210)