### PR TITLE
Add docs link to metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,6 @@
 name: coredns
 summary: CoreDNS
+docs: https://discourse.charmhub.io/t/coredns-docs-index/6322
 maintainers:
   - Cory Johns <cory.johns@canonical.com>
 description: |


### PR DESCRIPTION
This PR adds a charmhub discourse link to the docs field of the metadata.yaml file so that docs will be correctly displayed in charmhub.