### PR TITLE
recommit fix for LP#1903313

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -35,7 +35,7 @@ class CoreDNSCharm(CharmBase):
 
         if not self.unit.is_leader():
             # We can't do anything useful when not the leader, so do nothing.
-            self.model.unit.status = WaitingStatus("Waiting for leadership")
+            self.model.unit.status = ActiveStatus()
             return
 
         dns_udp = ServicePort(53, protocol="UDP", name="dns")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,6 +2,7 @@ from unittest.mock import call
 import logging
 from charm import CoreDNSCharm
 from ops.testing import Harness
+from ops.model import ActiveStatus
 from string import Template
 
 logger = logging.getLogger(__name__)
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 def test_not_leader():
     harness = Harness(CoreDNSCharm)
     harness.begin()
-    assert harness.charm.model.unit.status.name == "waiting"
+    assert isinstance(harness.charm.model.unit.status, ActiveStatus)
 
 
 def test_coredns_pebble_ready(harness, container):


### PR DESCRIPTION
The [fix](https://github.com/charmed-kubernetes/charm-coredns/commit/cac33283e5497d7e2c402201dedd0f52bfdf5a78) for [LP#1903313](https://bugs.launchpad.net/operator-metallb/+bug/1903313) appears to have been reverted by the [switch to sidecar](https://github.com/charmed-kubernetes/charm-coredns/commit/f42293d135bb7c620ba4cc33835d4c37416cc960).

Recommitting that fix