### PR TITLE
Disallow charm from being deployed to non-k8s models

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,3 +20,5 @@ resources:
     type: oci-image
     description: 'CoreDNS image'
     upstream-source: coredns/coredns:1.10.1
+assumes:
+  - k8s-api


### PR DESCRIPTION
Fixes https://bugs.launchpad.net/bugs/2032822