### PR TITLE
Enable topologySpreadConstraints to be configurable

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -53,6 +53,20 @@ config:
       description: Memory limit for each CoreDNS pod.
       type: string
       default: 170Mi
+    topology_spread_constraints:
+      description: |-
+        Topology spread constraints for CoreDNS pods, in YAML list format.
+        This controls how pods are distributed across failure domains
+        (e.g. nodes, zones) to improve high availability when multiple
+        replicas are deployed.  Set to '' to disable.
+      type: string
+      default: |
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              k8s-app: kube-dns
     coredns_namespace:
       description: |-
         An existing namespace to deploy CoreDNS into.

--- a/src/coredns_manifests.py
+++ b/src/coredns_manifests.py
@@ -6,12 +6,18 @@ import hashlib
 import json
 import logging
 from string import Template
-from typing import Dict, Optional, Type, TypeVar
+from typing import Dict, List, Optional, Type, TypeVar
 
+import yaml
 from httpx import HTTPError
 from lightkube.core.resource import NamespacedResource
 from lightkube.models.apps_v1 import Deployment
-from lightkube.models.core_v1 import ConfigMap, Service, ServiceAccount
+from lightkube.models.core_v1 import (
+    ConfigMap,
+    Service,
+    ServiceAccount,
+    TopologySpreadConstraint,
+)
 from lightkube.models.rbac_v1 import ClusterRole, ClusterRoleBinding
 from lightkube.resources.core_v1 import Service as Service_Res
 from ops.manifests import ConfigRegistry, ManifestLabel, Manifests, Patch
@@ -106,6 +112,9 @@ class AdjustDeployment(Patch):
         memory_limit = self.manifests.config.get("coredns_memory_limit", "170Mi")
         obj.spec.replicas = self.manifests.config.get("coredns_replicas", 1)
         obj.spec.template.spec.automountServiceAccountToken = True
+        obj.spec.template.spec.topologySpreadConstraints = (
+            self._topology_spread_constraints
+        )
         assert len(containers) == 1
         container = containers[0]
         assert container.resources.limits
@@ -113,6 +122,19 @@ class AdjustDeployment(Patch):
             f"Setting memory limit for container {container.name} to {memory_limit}"
         )
         container.resources.limits["memory"] = memory_limit
+
+    @property
+    def _topology_spread_constraints(self) -> Optional[List[TopologySpreadConstraint]]:
+        """Return the list of TopologySpreadConstraints from config, or None if unset."""
+        tsc_yaml = self.manifests.config.get("topology_spread_constraints", "")
+        if not tsc_yaml:
+            return None
+        tsc_data = yaml.safe_load(tsc_yaml)
+        if not isinstance(tsc_data, list):
+            log.warning("topology_spread_constraints is not a YAML list; ignoring")
+            return None
+        log.debug("Applying %d topology spread constraint(s)", len(tsc_data))
+        return [TopologySpreadConstraint.from_dict(tsc) for tsc in tsc_data]
 
 
 class AdjustService(Patch):

--- a/tests/unit/test_coredns_manifests.py
+++ b/tests/unit/test_coredns_manifests.py
@@ -1,4 +1,5 @@
 import pytest
+import yaml
 
 from coredns_manifests import CoreDNSManifests
 
@@ -49,3 +50,61 @@ def test_namespace_config(harness, manifest):
     with pytest.raises(KeyError):
         manifest.resources
     assert "coredns_namespace" in manifest.evaluate()
+
+
+def _get_deployment(manifest):
+    """Return the coredns Deployment resource from the manifest."""
+    return next(r for r in manifest.resources if r.kind == "Deployment")
+
+
+def test_topology_spread_constraints_default(harness, manifest):
+    """Default config sets a topology spread constraint for node-level distribution."""
+    deployment = _get_deployment(manifest)
+    tscs = deployment.resource.spec.template.spec.topologySpreadConstraints
+    assert tscs, "Expected at least one topology spread constraint by default"
+    assert len(tscs) == 1
+    tsc = tscs[0]
+    assert tsc.maxSkew == 1
+    assert tsc.topologyKey == "kubernetes.io/hostname"
+    assert tsc.whenUnsatisfiable == "ScheduleAnyway"
+    assert tsc.labelSelector is not None
+    assert tsc.labelSelector.matchLabels == {"k8s-app": "kube-dns"}
+
+
+def test_topology_spread_constraints_empty(harness, manifest):
+    """Setting topology_spread_constraints to '' disables the feature."""
+    harness.update_config({"topology_spread_constraints": ""})
+    deployment = _get_deployment(manifest)
+    tscs = deployment.resource.spec.template.spec.topologySpreadConstraints
+    assert not tscs
+
+
+def test_topology_spread_constraints_custom(harness, manifest):
+    """A custom topology_spread_constraints YAML string is applied correctly."""
+    custom = yaml.dump(
+        [
+            {
+                "maxSkew": 2,
+                "topologyKey": "topology.kubernetes.io/zone",
+                "whenUnsatisfiable": "DoNotSchedule",
+                "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+            }
+        ]
+    )
+    harness.update_config({"topology_spread_constraints": custom})
+    deployment = _get_deployment(manifest)
+    tscs = deployment.resource.spec.template.spec.topologySpreadConstraints
+    assert tscs and len(tscs) == 1
+    tsc = tscs[0]
+    assert tsc.maxSkew == 2
+    assert tsc.topologyKey == "topology.kubernetes.io/zone"
+    assert tsc.whenUnsatisfiable == "DoNotSchedule"
+
+
+def test_topology_spread_constraints_invalid_yaml(harness, manifest):
+    """Non-list YAML for topology_spread_constraints is silently ignored."""
+    harness.update_config({"topology_spread_constraints": "not-a-list: true"})
+    deployment = _get_deployment(manifest)
+    # Should not raise; constraints should be None/empty
+    tscs = deployment.resource.spec.template.spec.topologySpreadConstraints
+    assert not tscs


### PR DESCRIPTION
This controls how pods are distributed across failure domains to improve high availability when multiple replicas are deployed.

Fixes LP#2141516.